### PR TITLE
Fix some edge cases + ADD support for SearXNG

### DIFF
--- a/recursive/engine.py
+++ b/recursive/engine.py
@@ -17,7 +17,7 @@ from recursive.memory import caches
 from recursive.cache import Cache
 from recursive.utils.get_index import get_report_with_ref
 from datetime import datetime
-
+import os
     
     
 class GraphRunEngine:
@@ -434,7 +434,7 @@ def report_writing(input_filename,
             "execute": {
                 "react_agent": True, # use Search Agent
                 "prompt_version": "SearchAgentENPrompt", # see recursive.agent.prompts.search_agent.main
-                "searcher_type": "SerpApiSearch", # see recursive.executor.actions.bing_browser
+                "searcher_type": "SearXNG" if str(engine_backend).lower() == 'searxng' else "SerpApiSearch", # see recursive.executor.actions.bing_browser
                 "llm_args": {
                     "model": global_use_model, # set the llm
                 },

--- a/recursive/executor/agents/claude_fc_react.py
+++ b/recursive/executor/agents/claude_fc_react.py
@@ -289,13 +289,14 @@ class SearchAgent(BaseAgent):
         results = []
         for turn_idx, current_turn_info in enumerate(return_info[:-1]):
             turn_result = current_turn_info["tool_result"]
-            result = {
-                "turn": current_turn_info["turn"],
-                "web_pages": turn_result["web_pages"], # = web_pages (selected)
-                "xml_format_result": turn_result["result"], # = xml concat web pages
-                "observation": return_info[turn_idx+1]["observation"],
-            }
-            results.append(result)
+            if turn_result:
+                result = {
+                    "turn": current_turn_info["turn"],
+                    "web_pages": turn_result["web_pages"], # = web_pages (selected)
+                    "xml_format_result": turn_result["result"], # = xml concat web pages
+                    "observation": return_info[turn_idx+1]["observation"],
+                }
+                results.append(result)
         
         return {
             "ori": return_info,

--- a/recursive/graph.py
+++ b/recursive/graph.py
@@ -448,8 +448,8 @@ class AbstractNode(ABC):
                     if "length" not in task:
                         task["length"] = self.task_info["length"]
 
-            task_info = {key:task[key] for key in self.config["require_keys"][self.config["tag2task_type"][task["task_type"]]]}
-            
+            task_info = {key: task.get(key) for key in self.config["require_keys"].get(self.config["tag2task_type"].get(task.get("task_type")), [])}
+
             if "sub_tasks" in task:
                 task_info["candidate_plan"] = task["sub_tasks"]
                 for st in task["sub_tasks"]:


### PR DESCRIPTION
Hello,

Nice work!

This commit:
- adds the support of SearXNG as searcher_type to enable free evaluation while still sticking to SerpAPI if searxng is not specified as engine_backend or searcher_type directly set to SearXNG.
- fixes some edge cases where: search return no result, llm returns malformed task_info in order to avoid crash.

Xavier