### PR TITLE
Add optional local Ollama model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ WriteHERE is developed with these core principles:
   - OpenAI (GPT models)
   - Anthropic (Claude models)
   - SerpAPI (for search functionality in report generation)
+- Optional: a running local Ollama server for local models such as Qwen
 
 ### Quickstart
 
@@ -90,6 +91,16 @@ Example for generating a report:
 python engine.py --filename ../test_data/qa_test.jsonl --output-filename ./project/qa/result.jsonl --done-flag-file ./project/qa/done.txt --model claude-3-sonnet --mode report
 ```
 
+List locally installed Ollama models:
+```bash
+python engine.py --list-local-models
+```
+
+Run with a local Ollama model by using the `ollama/` prefix. WriteHERE only discovers installed models; it does not install Ollama or pull model weights.
+```bash
+OLLAMA_MODELS_DIR="$HOME/.ollama/models" python engine.py --filename ../test_data/meta_fiction.jsonl --output-filename ./project/story/output.jsonl --done-flag-file ./project/story/done.txt --model ollama/qwen2.5:7b --mode story
+```
+
 #### Running With Visualization Interface
 
 This option provides a web interface to visualize and monitor the writing process in real-time.
@@ -103,6 +114,7 @@ This option provides a web interface to visualize and monitor the writing proces
 This will:
 - Create a clean Python virtual environment
 - Install all required dependencies
+- Ask whether to discover local Ollama models without installing or pulling Ollama
 - Start the backend server on port 5001
 - Start the frontend on port 3000
 - Open your browser at http://localhost:3000

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,8 @@ Request body:
 }
 ```
 
+Use local Ollama models with the `ollama/` prefix, for example `ollama/qwen2.5:7b`. Local models do not require cloud API keys, but Ollama must already be running locally.
+
 ### Generate Report
 ```
 POST /api/generate-report
@@ -67,6 +69,12 @@ GET /api/status/{taskId}
 ```
 GET /api/result/{taskId}
 ```
+
+### List Models
+```
+GET /api/models
+```
+Returns built-in online model suggestions plus local Ollama models discovered from `OLLAMA_MODELS_DIR` or `~/.ollama/models`.
 
 ## Integration with Frontend
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -12,8 +12,13 @@ import shutil
 import re
 import signal
 import argparse
+import shlex
+import sys
 from pathlib import Path
 from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../recursive/llm")))
+from local_models import build_model_options
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description='Backend server for WriteHERE application')
@@ -34,6 +39,36 @@ socketio = SocketIO(app,
 task_storage = {}
 RESULTS_DIR = os.path.join(os.path.dirname(__file__), 'results')
 os.makedirs(RESULTS_DIR, exist_ok=True)
+
+ONLINE_MODEL_OPTIONS = [
+    {"label": "Claude 3.7 Sonnet (Recommended)", "value": "claude-3-7-sonnet-20250219", "provider": "anthropic", "local": False},
+    {"label": "Claude 3.5 Sonnet", "value": "claude-3-5-sonnet-20241022", "provider": "anthropic", "local": False},
+    {"label": "GPT-4o", "value": "gpt-4o", "provider": "openai", "local": False},
+    {"label": "GPT-4o-mini", "value": "gpt-4o-mini", "provider": "openai", "local": False},
+    {"label": "Gemini 2.5 Pro Exp", "value": "gemini-2.5-pro-exp-03-25", "provider": "gemini", "local": False},
+    {"label": "Gemini 2.5 Pro Preview", "value": "gemini-2.5-pro-preview-03-25", "provider": "gemini", "local": False},
+]
+
+
+def write_task_env_file(env_file, api_keys):
+    def write_env_value(file_obj, key, value):
+        file_obj.write(f"{key}={shlex.quote(str(value))}\n")
+
+    with open(env_file, 'w') as f:
+        if 'openai' in api_keys and api_keys['openai']:
+            write_env_value(f, "OPENAI", api_keys['openai'])
+        if 'claude' in api_keys and api_keys['claude']:
+            write_env_value(f, "CLAUDE", api_keys['claude'])
+        if 'gemini' in api_keys and api_keys['gemini']:
+            write_env_value(f, "GEMINI", api_keys['gemini'])
+        if 'serpapi' in api_keys and api_keys['serpapi']:
+            write_env_value(f, "SERPAPI", api_keys['serpapi'])
+        if os.getenv('OLLAMA_BASE_URL'):
+            write_env_value(f, "OLLAMA_BASE_URL", os.getenv('OLLAMA_BASE_URL'))
+        if os.getenv('OLLAMA_API_KEY'):
+            write_env_value(f, "OLLAMA_API_KEY", os.getenv('OLLAMA_API_KEY'))
+        if os.getenv('OLLAMA_MODELS_DIR'):
+            write_env_value(f, "OLLAMA_MODELS_DIR", os.getenv('OLLAMA_MODELS_DIR'))
 
 def reload_task_storage():
     """Reload task storage from the file system"""
@@ -117,24 +152,17 @@ def run_story_generation(task_id, prompt, model, api_keys):
     
     # Create environment file with API keys
     env_file = os.path.join(task_dir, 'api_key.env')
-    with open(env_file, 'w') as f:
-        if 'openai' in api_keys and api_keys['openai']:
-            f.write(f"OPENAI={api_keys['openai']}\n")
-        if 'claude' in api_keys and api_keys['claude']:
-            f.write(f"CLAUDE={api_keys['claude']}\n")
-        if 'gemini' in api_keys and api_keys['gemini']:
-            f.write(f"GEMINI={api_keys['gemini']}\n")
-        if 'serpapi' in api_keys and api_keys['serpapi']:
-            f.write(f"SERPAPI={api_keys['serpapi']}\n")
+    write_task_env_file(env_file, api_keys)
     
     # Create a script to run the engine with the appropriate environment
     script_path = os.path.join(task_dir, 'run.sh')
+    recursive_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../recursive'))
     with open(script_path, 'w') as f:
         f.write(f"""#!/bin/bash
-        cd {os.path.abspath(os.path.join(os.path.dirname(__file__), '../recursive'))}
-        source {env_file}
-        export TASK_ENV_FILE={env_file}
-        python engine.py --filename {input_file} --output-filename {output_file} --done-flag-file {done_file} --model {model} --mode story --nodes-json-file {nodes_file}
+        cd {shlex.quote(recursive_dir)}
+        source {shlex.quote(env_file)}
+        export TASK_ENV_FILE={shlex.quote(env_file)}
+        python engine.py --filename {shlex.quote(input_file)} --output-filename {shlex.quote(output_file)} --done-flag-file {shlex.quote(done_file)} --model {shlex.quote(model)} --mode story --nodes-json-file {shlex.quote(nodes_file)}
         """)
     
     os.chmod(script_path, 0o755)
@@ -210,26 +238,19 @@ def run_report_generation(task_id, prompt, model, enable_search, search_engine, 
     
     # Create environment file with API keys
     env_file = os.path.join(task_dir, 'api_key.env')
-    with open(env_file, 'w') as f:
-        if 'openai' in api_keys and api_keys['openai']:
-            f.write(f"OPENAI={api_keys['openai']}\n")
-        if 'claude' in api_keys and api_keys['claude']:
-            f.write(f"CLAUDE={api_keys['claude']}\n")
-        if 'gemini' in api_keys and api_keys['gemini']:
-            f.write(f"GEMINI={api_keys['gemini']}\n")
-        if 'serpapi' in api_keys and api_keys['serpapi']:
-            f.write(f"SERPAPI={api_keys['serpapi']}\n")
+    write_task_env_file(env_file, api_keys)
     
     # Create a script to run the engine with the appropriate environment
     script_path = os.path.join(task_dir, 'run.sh')
     engine_backend = search_engine if enable_search else "none"
     
+    recursive_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../recursive'))
     with open(script_path, 'w') as f:
         f.write(f"""#!/bin/bash
-        cd {os.path.abspath(os.path.join(os.path.dirname(__file__), '../recursive'))}
-        source {env_file}
-        export TASK_ENV_FILE={env_file}
-        python engine.py --filename {input_file} --output-filename {output_file} --done-flag-file {done_file} --model {model} --engine-backend {engine_backend} --mode report --nodes-json-file {nodes_file}
+        cd {shlex.quote(recursive_dir)}
+        source {shlex.quote(env_file)}
+        export TASK_ENV_FILE={shlex.quote(env_file)}
+        python engine.py --filename {shlex.quote(input_file)} --output-filename {shlex.quote(output_file)} --done-flag-file {shlex.quote(done_file)} --model {shlex.quote(model)} --engine-backend {shlex.quote(engine_backend)} --mode report --nodes-json-file {shlex.quote(nodes_file)}
         """)
     
     os.chmod(script_path, 0o755)
@@ -276,6 +297,17 @@ def run_report_generation(task_id, prompt, model, enable_search, search_engine, 
     except Exception as e:
         task_storage[task_id]["status"] = "error"
         task_storage[task_id]["error"] = str(e)
+
+@app.route('/api/models', methods=['GET'])
+def api_get_models():
+    local_models = build_model_options()
+    return jsonify({
+        "models": ONLINE_MODEL_OPTIONS + local_models,
+        "localModels": local_models,
+        "ollamaModelsDir": os.getenv("OLLAMA_MODELS_DIR", str(Path.home() / ".ollama" / "models")),
+        "ollamaBaseUrl": os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+    })
+
 
 @app.route('/api/generate-story', methods=['POST'])
 def api_generate_story():

--- a/frontend/src/pages/ReportGenerationPage.js
+++ b/frontend/src/pages/ReportGenerationPage.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Container, 
-  Typography, 
-  TextField, 
-  Button, 
-  Box, 
-  Paper, 
+import {
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Box,
+  Paper,
   Grid,
   FormControl,
   InputLabel,
@@ -33,7 +33,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import InfoIcon from '@mui/icons-material/Info';
-import { generateReport, pingAPI } from '../utils/api';
+import { generateReport, getModels, pingAPI } from '../utils/api';
 import HistoryPanel from '../components/HistoryPanel';
 
 // Recommended model options
@@ -55,6 +55,7 @@ const examplePrompts = [
 const ReportGenerationPage = () => {
   const [prompt, setPrompt] = useState('');
   const [model, setModel] = useState('claude-3-5-sonnet-20241022');
+  const [modelOptions, setModelOptions] = useState(commonModels);
   const [searchEngine, setSearchEngine] = useState('google');
   const [enableSearch, setEnableSearch] = useState(true);
   const [apiKeys, setApiKeys] = useState({
@@ -73,7 +74,7 @@ const ReportGenerationPage = () => {
   const [statusMessage, setStatusMessage] = useState('');
   const [showStatus, setShowStatus] = useState(false);
   const navigate = useNavigate();
-  
+
   // Save API keys to localStorage when they change
   useEffect(() => {
     if (apiKeys.openai) localStorage.setItem('openai_api_key', apiKeys.openai);
@@ -81,7 +82,7 @@ const ReportGenerationPage = () => {
     if (apiKeys.gemini) localStorage.setItem('gemini_api_key', apiKeys.gemini);
     if (apiKeys.serpapi) localStorage.setItem('serpapi_api_key', apiKeys.serpapi);
   }, [apiKeys]);
-  
+
   const handleApiKeyChange = (provider, value) => {
     setApiKeys(prev => ({
       ...prev,
@@ -99,47 +100,63 @@ const ReportGenerationPage = () => {
         setError('Cannot connect to the backend server. Please make sure it is running at http://localhost:' + (process.env.REACT_APP_BACKEND_PORT || '5001') + '.');
       }
     }
-    
+
     checkAPIConnection();
+  }, []);
+
+  useEffect(() => {
+    async function loadModelOptions() {
+      try {
+        const response = await getModels();
+        if (response.models && response.models.length > 0) {
+          setModelOptions(response.models);
+        }
+      } catch (err) {
+        console.warn('Using built-in model options because /api/models failed:', err);
+      }
+    }
+
+    loadModelOptions();
   }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
     if (!prompt) {
       setError('Please provide a prompt for report generation.');
       return;
     }
-    
+
     // Check if the appropriate API keys are provided
     const isOpenAIModel = model.toLowerCase().includes('gpt');
     const isClaudeModel = model.toLowerCase().includes('claude');
     const isGeminiModel = model.toLowerCase().includes('gemini');
-    
-    if (isOpenAIModel && !apiKeys.openai) {
+    const isOllamaModel = model.toLowerCase().startsWith('ollama/');
+
+    if (!isOllamaModel && isOpenAIModel && !apiKeys.openai) {
       setError('Please provide your OpenAI API key in the settings section.');
       setShowApiSection(true);
       return;
     }
-    
-    if (isClaudeModel && !apiKeys.claude) {
+
+    if (!isOllamaModel && isClaudeModel && !apiKeys.claude) {
       setError('Please provide your Anthropic Claude API key in the settings section.');
       setShowApiSection(true);
       return;
     }
-    
-    if (isGeminiModel && !apiKeys.gemini) {
+
+    if (!isOllamaModel && isGeminiModel && !apiKeys.gemini) {
       setError('Please provide your Google Gemini API key in the settings section.');
       setShowApiSection(true);
       return;
     }
-    
+
     if (enableSearch && !apiKeys.serpapi) {
       setError('Please provide your SerpAPI key in the settings section to enable search functionality.');
       setShowApiSection(true);
       return;
     }
-    
+
     // First, check if the server is reachable
     try {
       await pingAPI();
@@ -147,12 +164,12 @@ const ReportGenerationPage = () => {
       setError('Cannot connect to the backend server. Please make sure it is running at http://localhost:' + (process.env.REACT_APP_BACKEND_PORT || '5001') + '.');
       return;
     }
-    
+
     setLoading(true);
     setError('');
     setStatusMessage('Initiating report generation...');
     setShowStatus(true);
-    
+
     try {
       // Call the backend API to start report generation
       const response = await generateReport({
@@ -167,19 +184,19 @@ const ReportGenerationPage = () => {
           serpapi: apiKeys.serpapi
         }
       });
-      
+
       // Navigate to the results page with the task ID
       if (response && response.taskId) {
         setStatusMessage('Report generation started successfully!');
-        navigate(`/results/${response.taskId}`, { 
-          state: { 
+        navigate(`/results/${response.taskId}`, {
+          state: {
             taskId: response.taskId,
             prompt,
             model,
             searchEngine: enableSearch ? searchEngine : 'none',
             type: 'report',
             status: 'generating'
-          } 
+          }
         });
       } else {
         throw new Error('No task ID returned from the server');
@@ -204,7 +221,7 @@ const ReportGenerationPage = () => {
         </Typography>
         <Typography variant="body1" paragraph>
           Generate comprehensive technical reports using our Heterogeneous Recursive Planning framework.
-          The system integrates information retrieval, logical reasoning, and content composition to 
+          The system integrates information retrieval, logical reasoning, and content composition to
           create well-structured and informative reports.
         </Typography>
       </Box>
@@ -214,9 +231,9 @@ const ReportGenerationPage = () => {
           {error}
         </Alert>
       )}
-      
+
       <HistoryPanel />
-      
+
       <Snackbar
         open={showStatus}
         autoHideDuration={6000}
@@ -244,7 +261,7 @@ const ReportGenerationPage = () => {
             <Grid item xs={12} md={4}>
               <Autocomplete
                 freeSolo
-                options={commonModels}
+                options={modelOptions}
                 getOptionLabel={(option) => {
                   if (typeof option === 'string') {
                     return option;
@@ -281,12 +298,12 @@ const ReportGenerationPage = () => {
                     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                       <Typography variant="body1">{option.label}</Typography>
                       <Typography variant="caption" color="text.secondary">
-                        {option.value}
+                        {option.provider ? `${option.provider} - ${option.value}` : option.value}
                       </Typography>
                     </Box>
                   </li>
                 )}
-                renderTags={(value, getTagProps) => 
+                renderTags={(value, getTagProps) =>
                   value.map((option, index) => (
                     <Chip
                       label={option.label}
@@ -301,14 +318,14 @@ const ReportGenerationPage = () => {
             <Grid item xs={12} md={4}>
               <FormControlLabel
                 control={
-                  <Switch 
-                    checked={enableSearch} 
-                    onChange={(e) => setEnableSearch(e.target.checked)} 
+                  <Switch
+                    checked={enableSearch}
+                    onChange={(e) => setEnableSearch(e.target.checked)}
                   />
                 }
                 label="Enable Search"
               />
-              
+
               <FormControl fullWidth sx={{ mt: 1 }} disabled={!enableSearch}>
                 <InputLabel id="search-engine-label">Search Engine</InputLabel>
                 <Select
@@ -336,9 +353,9 @@ const ReportGenerationPage = () => {
                 {loading ? <CircularProgress size={24} color="inherit" /> : 'Generate Report'}
               </Button>
             </Grid>
-            
+
             <Grid item xs={12}>
-              <Accordion 
+              <Accordion
                 expanded={showApiSection}
                 onChange={() => setShowApiSection(!showApiSection)}
                 sx={{
@@ -499,13 +516,13 @@ const ReportGenerationPage = () => {
         <Typography variant="body2" paragraph>
           Click on any example to use it as your prompt:
         </Typography>
-        
+
         <Grid container spacing={3}>
           {examplePrompts.map((example, index) => (
             <Grid item xs={12} md={4} key={index}>
-              <Card 
-                sx={{ 
-                  height: '100%', 
+              <Card
+                sx={{
+                  height: '100%',
                   cursor: 'pointer',
                   transition: 'transform 0.2s',
                   '&:hover': {

--- a/frontend/src/pages/StoryGenerationPage.js
+++ b/frontend/src/pages/StoryGenerationPage.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Container, 
-  Typography, 
-  TextField, 
-  Button, 
-  Box, 
-  Paper, 
+import {
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Box,
+  Paper,
   Grid,
   FormControl,
   InputLabel,
@@ -31,7 +31,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import InfoIcon from '@mui/icons-material/Info';
-import { generateStory, pingAPI } from '../utils/api';
+import { generateStory, getModels, pingAPI } from '../utils/api';
 import HistoryPanel from '../components/HistoryPanel';
 
 // Recommended model options
@@ -54,6 +54,7 @@ const examplePrompts = [
 const StoryGenerationPage = () => {
   const [prompt, setPrompt] = useState('');
   const [model, setModel] = useState('claude-3-7-sonnet-20250219');
+  const [modelOptions, setModelOptions] = useState(commonModels);
   const [apiKeys, setApiKeys] = useState({
     openai: localStorage.getItem('openai_api_key') || '',
     claude: localStorage.getItem('claude_api_key') || '',
@@ -68,7 +69,7 @@ const StoryGenerationPage = () => {
   const [statusMessage, setStatusMessage] = useState('');
   const [showStatus, setShowStatus] = useState(false);
   const navigate = useNavigate();
-  
+
   // Save API keys to localStorage when they change
   useEffect(() => {
     if (apiKeys.openai) localStorage.setItem('openai_api_key', apiKeys.openai);
@@ -86,41 +87,57 @@ const StoryGenerationPage = () => {
         setError('Cannot connect to the backend server. Please make sure it is running at http://localhost:' + (process.env.REACT_APP_BACKEND_PORT || '5001') + '.');
       }
     }
-    
+
     checkAPIConnection();
+  }, []);
+
+  useEffect(() => {
+    async function loadModelOptions() {
+      try {
+        const response = await getModels();
+        if (response.models && response.models.length > 0) {
+          setModelOptions(response.models);
+        }
+      } catch (err) {
+        console.warn('Using built-in model options because /api/models failed:', err);
+      }
+    }
+
+    loadModelOptions();
   }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
     if (!prompt) {
       setError('Please provide a prompt for story generation.');
       return;
     }
-    
+
     // Check if the appropriate API key is provided
     const isOpenAIModel = model.toLowerCase().includes('gpt');
     const isClaudeModel = model.toLowerCase().includes('claude');
     const isGeminiModel = model.toLowerCase().includes('gemini');
-    
-    if (isOpenAIModel && !apiKeys.openai) {
+    const isOllamaModel = model.toLowerCase().startsWith('ollama/');
+
+    if (!isOllamaModel && isOpenAIModel && !apiKeys.openai) {
       setError('Please provide your OpenAI API key in the settings section.');
       setShowApiSection(true);
       return;
     }
-    
-    if (isClaudeModel && !apiKeys.claude) {
+
+    if (!isOllamaModel && isClaudeModel && !apiKeys.claude) {
       setError('Please provide your Anthropic Claude API key in the settings section.');
       setShowApiSection(true);
       return;
     }
-    
-    if (isGeminiModel && !apiKeys.gemini) {
+
+    if (!isOllamaModel && isGeminiModel && !apiKeys.gemini) {
       setError('Please provide your Google Gemini API key in the settings section.');
       setShowApiSection(true);
       return;
     }
-    
+
     // First, check if the server is reachable
     try {
       await pingAPI();
@@ -128,12 +145,12 @@ const StoryGenerationPage = () => {
       setError('Cannot connect to the backend server. Please make sure it is running at http://localhost:' + (process.env.REACT_APP_BACKEND_PORT || '5001') + '.');
       return;
     }
-    
+
     setLoading(true);
     setError('');
     setStatusMessage('Initiating story generation...');
     setShowStatus(true);
-    
+
     try {
       // Call the backend API to start story generation
       const response = await generateStory({
@@ -145,18 +162,18 @@ const StoryGenerationPage = () => {
           gemini: apiKeys.gemini
         }
       });
-      
+
       // Navigate to the results page with the task ID
       if (response && response.taskId) {
         setStatusMessage('Story generation started successfully!');
-        navigate(`/results/${response.taskId}`, { 
-          state: { 
+        navigate(`/results/${response.taskId}`, {
+          state: {
             taskId: response.taskId,
             prompt,
             model,
             type: 'story',
             status: 'generating'
-          } 
+          }
         });
       } else {
         throw new Error('No task ID returned from the server');
@@ -168,7 +185,7 @@ const StoryGenerationPage = () => {
       console.error('Story generation error:', err);
     }
   };
-  
+
   const handleApiKeyChange = (provider, value) => {
     setApiKeys(prev => ({
       ...prev,
@@ -187,8 +204,8 @@ const StoryGenerationPage = () => {
           Creative Story Generation
         </Typography>
         <Typography variant="body1" paragraph>
-          Generate creative stories using our Heterogeneous Recursive Planning framework. 
-          Provide a prompt describing the story you want to create, and our system will 
+          Generate creative stories using our Heterogeneous Recursive Planning framework.
+          Provide a prompt describing the story you want to create, and our system will
           recursively plan and generate a cohesive narrative.
         </Typography>
       </Box>
@@ -198,9 +215,9 @@ const StoryGenerationPage = () => {
           {error}
         </Alert>
       )}
-      
+
       <HistoryPanel />
-      
+
       <Snackbar
         open={showStatus}
         autoHideDuration={6000}
@@ -228,7 +245,7 @@ const StoryGenerationPage = () => {
             <Grid item xs={12} md={6}>
               <Autocomplete
                 freeSolo
-                options={commonModels}
+                options={modelOptions}
                 getOptionLabel={(option) => {
                   if (typeof option === 'string') {
                     return option;
@@ -265,12 +282,12 @@ const StoryGenerationPage = () => {
                     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                       <Typography variant="body1">{option.label}</Typography>
                       <Typography variant="caption" color="text.secondary">
-                        {option.value}
+                        {option.provider ? `${option.provider} - ${option.value}` : option.value}
                       </Typography>
                     </Box>
                   </li>
                 )}
-                renderTags={(value, getTagProps) => 
+                renderTags={(value, getTagProps) =>
                   value.map((option, index) => (
                     <Chip
                       label={option.label}
@@ -294,9 +311,9 @@ const StoryGenerationPage = () => {
                 {loading ? <CircularProgress size={24} color="inherit" /> : 'Generate Story'}
               </Button>
             </Grid>
-            
+
             <Grid item xs={12}>
-              <Accordion 
+              <Accordion
                 expanded={showApiSection}
                 onChange={() => setShowApiSection(!showApiSection)}
                 sx={{
@@ -424,13 +441,13 @@ const StoryGenerationPage = () => {
         <Typography variant="body2" paragraph>
           Click on any example to use it as your prompt:
         </Typography>
-        
+
         <Grid container spacing={3}>
           {examplePrompts.map((example, index) => (
             <Grid item xs={12} md={4} key={index}>
-              <Card 
-                sx={{ 
-                  height: '100%', 
+              <Card
+                sx={{
+                  height: '100%',
                   cursor: 'pointer',
                   transition: 'transform 0.2s',
                   '&:hover': {
@@ -462,7 +479,7 @@ const StoryGenerationPage = () => {
               Be Specific
             </Typography>
             <Typography variant="body2">
-              Provide specific details about the characters, setting, and plot elements 
+              Provide specific details about the characters, setting, and plot elements
               you want in your story.
             </Typography>
           </Grid>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -34,6 +34,20 @@ export const pingAPI = async () => {
 };
 
 /**
+ * Fetches online and discovered local model options.
+ * @returns {Promise} - Promise that resolves with model metadata
+ */
+export const getModels = async () => {
+  try {
+    const response = await apiClient.get('/models');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching model options:', error);
+    throw error;
+  }
+};
+
+/**
  * Generates a story using the heterogeneous recursive planning engine
  * @param {Object} params - Generation parameters
  * @param {string} params.prompt - The story prompt

--- a/recursive/engine.py
+++ b/recursive/engine.py
@@ -1,5 +1,20 @@
 #coding:utf8
 
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+if "--list-local-models" in sys.argv:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "llm"))
+    from local_models import list_ollama_models
+
+    models = list_ollama_models()
+    if models:
+        print("\n".join(models))
+    else:
+        print("No local Ollama models found.")
+    raise SystemExit(0)
+
 from collections import defaultdict, deque
 from typing import List, Dict
 from recursive.graph import TaskStatus, RegularDummyNode, NodeType
@@ -17,7 +32,6 @@ from recursive.memory import caches
 from recursive.cache import Cache
 from recursive.utils.get_index import get_report_with_ref
 from datetime import datetime
-import os
     
     
 class GraphRunEngine:
@@ -586,10 +600,11 @@ def report_writing(input_filename,
                                  
 def define_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--filename", type=str, required=True)
-    parser.add_argument("--mode", type=str, choices=["story", "report"], required=True)
-    parser.add_argument("--output-filename", type=str, required=True)
-    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument("--filename", type=str)
+    parser.add_argument("--mode", type=str, choices=["story", "report"])
+    parser.add_argument("--output-filename", type=str)
+    parser.add_argument("--model", type=str)
+    parser.add_argument("--list-local-models", action="store_true", help="List discovered local Ollama models and exit")
     parser.add_argument("--length", type=int)
     parser.add_argument("--engine-backend", type=str)
     parser.add_argument("--nodes-json-file", type=str, help="Path to save nodes.json for real-time visualization")
@@ -607,6 +622,19 @@ def define_args():
 if __name__ == "__main__":
     parser = define_args()
     args = parser.parse_args()
+
+    required_args = {
+        "--filename": args.filename,
+        "--mode": args.mode,
+        "--output-filename": args.output_filename,
+        "--model": args.model,
+    }
+    missing_args = [name for name, value in required_args.items() if value is None]
+    if missing_args:
+        parser.error("the following arguments are required unless --list-local-models is used: {}".format(
+            ", ".join(missing_args)
+        ))
+
     if args.mode == "story":
         story_writing(args.filename, args.output_filename,
                       args.start, args.end, args.done_flag_file, args.model,

--- a/recursive/executor/actions/base_action.py
+++ b/recursive/executor/actions/base_action.py
@@ -145,7 +145,8 @@ def tool_api(func: Optional[Callable] = None,
             if doc.kind is DocstringSectionKind.parameters:
                 for d in doc.value:
                     d = d.as_dict()
-                    d['type'] = _detect_type(d["annotation"].lower())
+                    annotation = d.get("annotation") or ""
+                    d['type'] = _detect_type(annotation.lower())
                     args_doc[d['name']] = d
             if doc.kind is DocstringSectionKind.returns:
                 for d in doc.value:
@@ -163,11 +164,17 @@ def tool_api(func: Optional[Callable] = None,
         for name, param in sig.parameters.items():
             if name == 'self':
                 continue
+            param_doc = args_doc.get(param.name, {})
+            if "type" not in param_doc:
+                annotation = ""
+                if param.annotation is not inspect.Signature.empty:
+                    annotation = str(param.annotation)
+                param_doc["type"] = _detect_type(annotation.lower())
             parameter = dict(
                 name=param.name,
-                type=args_doc[param.name]["type"],
-                annotation=args_doc[param.name].get("annotation", ""),
-                description=args_doc[param.name]["description"])
+                type=param_doc["type"],
+                annotation=param_doc.get("annotation", ""),
+                description=param_doc.get("description", ""))
             desc['parameters'].append(parameter)
             if param.default is inspect.Signature.empty:
                 parameter["required"] = True

--- a/recursive/llm/llm.py
+++ b/recursive/llm/llm.py
@@ -129,20 +129,23 @@ class OpenAIApiProxy():
     def call(self, model, messages, no_cache = False, overwrite_cache=False, tools=None, temperature=None, headers={}, use_official=None, **kwargs):
         assert tools is None
         messages = copy.deepcopy(messages)
+        headers = headers.copy()
+        is_ollama = model.startswith("ollama/")
+        request_model = model[len("ollama/"):] if is_ollama else model
         
         # Check if model name includes openrouter model identifier
-        if any(provider in model for provider in ["google/", "anthropic/", "meta/", "mistral/"]):
+        if not is_ollama and any(provider in model for provider in ["google/", "anthropic/", "meta/", "mistral/"]):
             use_official = "openrouter"
 
         is_gpt = True if "gpt" in model or "o1" in model else False
     
         params_gpt = {
-            "model": model,
+            "model": request_model,
             "messages": messages,
             "max_tokens": 8192,
         }
         
-        if "claude" in model:
+        if not is_ollama and "claude" in model:
             use_official = "anthropic"
         
         if self.verbose:
@@ -151,7 +154,10 @@ class OpenAIApiProxy():
         if temperature is not None:
             params_gpt["temperature"] = temperature
 
-        if 'o1' in model:
+        if is_ollama:
+            url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1").rstrip("/") + "/chat/completions"
+            api_key = os.getenv("OLLAMA_API_KEY", "ollama")
+        elif 'o1' in model:
             url = ''
             api_key = ""
             params_gpt["max_tokens"] = 32768
@@ -177,7 +183,7 @@ class OpenAIApiProxy():
             genai.configure(api_key=api_key)
             url = None  # Not used for Gemini
 
-        if "o1" in model:
+        if not is_ollama and "o1" in model:
             if "temperature" in params_gpt:
                 del params_gpt["temperature"]
         
@@ -254,7 +260,7 @@ class OpenAIApiProxy():
                 raise
                 
         # Handle Gemini API
-        if "gemini" in model:
+        if not is_ollama and "gemini" in model:
             try:
                 # Process messages for Gemini format
                 gemini_messages = []

--- a/recursive/llm/local_models.py
+++ b/recursive/llm/local_models.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+
+
+DEFAULT_OLLAMA_MODELS_DIR = Path.home() / ".ollama" / "models"
+
+
+def get_ollama_models_dir():
+    """Return the Ollama models directory from env or the standard user path."""
+    configured = os.getenv("OLLAMA_MODELS_DIR", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return DEFAULT_OLLAMA_MODELS_DIR
+
+
+def list_ollama_models(models_dir=None):
+    """
+    Discover installed Ollama model manifests and return WriteHERE model ids.
+
+    Ollama stores manifests below:
+      ~/.ollama/models/manifests/<registry>/<namespace>/<model>/<tag>
+
+    WriteHERE exposes those as:
+      ollama/<model>:<tag>
+      ollama/<namespace>/<model>:<tag> when the namespace is not "library"
+    """
+    base_dir = Path(models_dir).expanduser() if models_dir else get_ollama_models_dir()
+    manifests_dir = base_dir / "manifests"
+    if not manifests_dir.exists() or not manifests_dir.is_dir():
+        return []
+
+    models = set()
+    for manifest in manifests_dir.rglob("*"):
+        if not manifest.is_file():
+            continue
+
+        rel_parts = manifest.relative_to(manifests_dir).parts
+        if len(rel_parts) < 4:
+            continue
+
+        namespace = rel_parts[-3]
+        model_name = rel_parts[-2]
+        tag = rel_parts[-1]
+
+        if namespace == "library":
+            ollama_name = f"{model_name}:{tag}"
+        else:
+            ollama_name = f"{namespace}/{model_name}:{tag}"
+        models.add(f"ollama/{ollama_name}")
+
+    return sorted(models)
+
+
+def build_model_options():
+    """Return frontend-ready metadata for discovered local Ollama models."""
+    return [
+        {
+            "label": f"Local Ollama - {model[len('ollama/'):] if model.startswith('ollama/') else model}",
+            "value": model,
+            "provider": "ollama",
+            "local": True,
+        }
+        for model in list_ollama_models()
+    ]

--- a/start.sh
+++ b/start.sh
@@ -45,6 +45,39 @@ check_api_keys() {
   fi
 }
 
+# Optionally expose locally installed Ollama models to the backend/frontend.
+configure_local_ollama() {
+  default_ollama_models_dir="$HOME/.ollama/models"
+
+  if [ ! -t 0 ]; then
+    log "Non-interactive shell detected; skipping local Ollama model discovery."
+    return
+  fi
+
+  read -r -p "Do you want to enable local Ollama models? [y/N]: " enable_ollama
+  case "$enable_ollama" in
+    y|Y|yes|YES)
+      read -r -p "Ollama models directory [$default_ollama_models_dir]: " ollama_models_dir
+      if [ -z "$ollama_models_dir" ]; then
+        ollama_models_dir="$default_ollama_models_dir"
+      fi
+      ollama_models_dir="${ollama_models_dir/#\~/$HOME}"
+      export OLLAMA_MODELS_DIR="$ollama_models_dir"
+      export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://localhost:11434/v1}"
+
+      if [ -d "$OLLAMA_MODELS_DIR/manifests" ]; then
+        log "Local Ollama discovery enabled: $OLLAMA_MODELS_DIR"
+      else
+        log "Local Ollama discovery enabled, but no manifests directory was found at: $OLLAMA_MODELS_DIR/manifests"
+        log "The app will still start; online models and manual model entry remain available."
+      fi
+      ;;
+    *)
+      log "Local Ollama model discovery disabled."
+      ;;
+  esac
+}
+
 # Check if a port is in use
 is_port_in_use() {
   if command -v nc >/dev/null 2>&1; then
@@ -57,6 +90,11 @@ is_port_in_use() {
     # Default to assuming port is free if we can't check
     return 1
   fi
+}
+
+cleanup_ports() {
+  # Port conflicts are handled in start_backend/start_frontend.
+  return 0
 }
 
 # Function to start the backend server
@@ -182,6 +220,9 @@ cleanup_ports
 
 # Ensure we have API keys or notify the user
 check_api_keys
+
+# Ask once whether local Ollama models should be exposed.
+configure_local_ollama
 
 # Start backend first
 start_backend


### PR DESCRIPTION
## Summary
Adds optional support for using locally installed Ollama models through WriteHERE.

Users can:
- opt into local model discovery when running `start.sh`
- select discovered `ollama/...` models in the frontend
- run CLI generation with `--model ollama/<model>`
- list discovered local models with `python engine.py --list-local-models`

This does not install Ollama, pull models, or change existing OpenAI/Claude/Gemini behavior.

## Motivation
WriteHERE currently requires hosted model APIs. This adds a privacy-friendly/local option for users who already run Ollama, while preserving existing API workflows.

## Implementation Notes
- Discovers installed Ollama manifests from `OLLAMA_MODELS_DIR` or `~/.ollama/models`
- Uses Ollama’s OpenAI-compatible endpoint at `OLLAMA_BASE_URL`, defaulting to `http://localhost:11434/v1`
- Prefixes local models as `ollama/<model>` to avoid conflicts with hosted model names
- Frontend model options remain dynamic via `/api/models`

## Testing
- `python3 -m pytest`
- `bash -n start.sh`
- `python recursive/engine.py --list-local-models`
- Verified `/api/models` returns online models plus discovered Ollama models


Example:
<img width="1236" height="694" alt="Screenshot 2026-05-04 at 4 57 51 PM" src="https://github.com/user-attachments/assets/e5f2ce64-7741-40a6-98b5-f2e5f02603bc" />
<img width="1053" height="718" alt="Screenshot 2026-05-04 at 5 00 20 PM" src="https://github.com/user-attachments/assets/b6a96d1c-9599-41c3-812c-f22ac5c7f1df" />
