### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ WriteHERE is developed with these core principles:
   - OpenAI (GPT models)
   - Anthropic (Claude models)
   - SerpAPI (for search functionality in report generation)
+  - Or any provider via [LiteLLM](https://github.com/BerriAI/litellm) (100+ providers)
 
 ### Quickstart
 
@@ -89,6 +90,19 @@ Example for generating a report:
 ```bash
 python engine.py --filename ../test_data/qa_test.jsonl --output-filename ./project/qa/result.jsonl --done-flag-file ./project/qa/done.txt --model claude-3-sonnet --mode report
 ```
+
+Example using LiteLLM (access 100+ providers with the `litellm/` prefix):
+```bash
+# AWS Bedrock
+python engine.py --filename ../test_data/meta_fiction.jsonl --output-filename ./project/story/output.jsonl --done-flag-file ./project/story/done.txt --model litellm/bedrock/anthropic.claude-3-sonnet-20240229-v1:0 --mode story
+
+# Azure OpenAI
+python engine.py ... --model litellm/azure/gpt-4 --mode story
+
+# Google Vertex AI
+python engine.py ... --model litellm/vertex_ai/gemini-pro --mode report
+```
+Set the provider's standard API key env var (e.g. `ANTHROPIC_API_KEY`, `AWS_ACCESS_KEY_ID`). Full list: https://docs.litellm.ai/docs/providers
 
 #### Running With Visualization Interface
 

--- a/recursive/llm/llm.py
+++ b/recursive/llm/llm.py
@@ -126,10 +126,68 @@ class OpenAIApiProxy():
         return data
 
 
+    def _call_litellm(self, model, messages, no_cache, overwrite_cache, temperature, **kwargs):
+        import litellm
+
+        params = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": 8192,
+            "drop_params": True,
+        }
+        if temperature is not None:
+            params["temperature"] = temperature
+
+        params.update(kwargs)
+
+        cache_name = "OpenAIApiProxy.call"
+        call_args_dict = copy.deepcopy(params)
+        llm_cache = caches["llm"]
+        if not no_cache and not overwrite_cache:
+            cache_result = llm_cache.get_cache(cache_name, call_args_dict)
+            if cache_result is not None:
+                return cache_result
+
+        response = None
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                response = litellm.completion(**params)
+                break
+            except Exception as e:
+                qualname = f"{type(e).__module__}.{type(e).__name__}"
+                transient = qualname in {
+                    "litellm.exceptions.RateLimitError",
+                    "litellm.exceptions.APIConnectionError",
+                    "litellm.exceptions.Timeout",
+                    "litellm.exceptions.InternalServerError",
+                    "litellm.exceptions.ServiceUnavailableError",
+                }
+                if not transient or attempt == self.MAX_RETRIES - 1:
+                    raise
+                sleep_time = self.BACKOFF_FACTOR
+                logger.warning(f"LiteLLM transient error (attempt {attempt + 1}): {e}")
+                time.sleep(sleep_time)
+
+        content = response.choices[0].message.content
+        usage = response.usage
+        if self.verbose and usage:
+            logger.debug(f"{model} Usage: input={usage.prompt_tokens}, output={usage.completion_tokens}")
+
+        result = [{"message": {"content": content}}]
+
+        if not no_cache:
+            llm_cache.save_cache(cache_name, call_args_dict, result)
+
+        return result
+
     def call(self, model, messages, no_cache = False, overwrite_cache=False, tools=None, temperature=None, headers={}, use_official=None, **kwargs):
         assert tools is None
         messages = copy.deepcopy(messages)
-        
+
+        # LiteLLM route: model starts with "litellm/" prefix
+        if model.startswith("litellm/"):
+            return self._call_litellm(model[len("litellm/"):], messages, no_cache, overwrite_cache, temperature, **kwargs)
+
         # Check if model name includes openrouter model identifier
         if any(provider in model for provider in ["google/", "anthropic/", "meta/", "mistral/"]):
             use_official = "openrouter"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ urllib3
 openai>=1.0.0
 anthropic>=0.5.0
 google-generativeai>=0.3.0
+litellm>=1.80,<1.87
 
 # Web and API dependencies
 requests>=2.28.2

--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -1,0 +1,251 @@
+"""Tests for the LiteLLM integration in OpenAIApiProxy."""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+# Stub recursive.memory so llm.py can be imported without the full package
+_mem = types.ModuleType("recursive")
+sys.modules.setdefault("recursive", _mem)
+_mem_memory = types.ModuleType("recursive.memory")
+
+
+class _FakeCache:
+    def __init__(self):
+        self.store = {}
+
+    def get_cache(self, name, args_dict):
+        key = str(args_dict)
+        return self.store.get(key)
+
+    def save_cache(self, name, args_dict, value):
+        key = str(args_dict)
+        self.store[key] = value
+
+
+_mem_memory.caches = {"llm": _FakeCache()}
+sys.modules.setdefault("recursive.memory", _mem_memory)
+
+
+def _make_response(content="Hello", prompt_tokens=10, completion_tokens=5):
+    """Build a fake litellm.completion() response matching ModelResponse shape."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        ),
+    )
+
+
+def _load_proxy():
+    """Import OpenAIApiProxy in isolation."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "llm", "recursive/llm/llm.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.OpenAIApiProxy
+
+
+class TestLiteLLMRouting:
+    """Verify the litellm/ prefix routes to _call_litellm."""
+
+    def test_litellm_prefix_routes_correctly(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        fake_resp = _make_response("test output")
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+
+            result = proxy.call(
+                model="litellm/anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "hi"}],
+                no_cache=True,
+            )
+
+        assert result == [{"message": {"content": "test output"}}]
+        litellm.completion.assert_called_once()
+        call_kwargs = litellm.completion.call_args
+        assert call_kwargs[1]["model"] == "anthropic/claude-sonnet-4-6"
+
+    def test_non_litellm_model_does_not_route_to_litellm(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        proxy.MAX_RETRIES = 1
+
+        with mock.patch.object(proxy, "_call_litellm") as mock_litellm, \
+             mock.patch.object(proxy.session, "post", side_effect=Exception("blocked")):
+            try:
+                proxy.call(
+                    model="gpt-4o",
+                    messages=[{"role": "user", "content": "hi"}],
+                    no_cache=True,
+                )
+            except Exception:
+                pass
+            mock_litellm.assert_not_called()
+
+
+class TestLiteLLMCallParams:
+    """Verify correct params are passed to litellm.completion."""
+
+    def test_drop_params_true_by_default(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        fake_resp = _make_response()
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+
+            proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                no_cache=True,
+            )
+
+        call_kwargs = litellm.completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_temperature_forwarded(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        fake_resp = _make_response()
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+
+            proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                no_cache=True,
+                temperature=0.3,
+            )
+
+        call_kwargs = litellm.completion.call_args[1]
+        assert call_kwargs["temperature"] == 0.3
+
+    def test_temperature_omitted_when_none(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        fake_resp = _make_response()
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+
+            proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                no_cache=True,
+            )
+
+        call_kwargs = litellm.completion.call_args[1]
+        assert "temperature" not in call_kwargs
+
+    def test_max_tokens_set_to_8192(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        fake_resp = _make_response()
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+
+            proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                no_cache=True,
+            )
+
+        call_kwargs = litellm.completion.call_args[1]
+        assert call_kwargs["max_tokens"] == 8192
+
+
+class TestLiteLLMCaching:
+    """Verify caching works for litellm calls."""
+
+    def test_cache_hit_skips_api_call(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        fake_resp = _make_response("first call")
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+
+            result1 = proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "cached?"}],
+                no_cache=False,
+            )
+            result2 = proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "cached?"}],
+                no_cache=False,
+            )
+
+        assert result1 == result2
+        assert litellm.completion.call_count == 1
+
+
+class TestLiteLLMRetry:
+    """Verify transient errors trigger retries, non-transient errors raise."""
+
+    def test_non_transient_error_raises_immediately(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+
+        auth_error = type("AuthenticationError", (Exception,), {
+            "__module__": "litellm.exceptions"
+        })()
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(side_effect=auth_error)
+
+            with pytest.raises(Exception):
+                proxy.call(
+                    model="litellm/openai/gpt-4o",
+                    messages=[{"role": "user", "content": "hi"}],
+                    no_cache=True,
+                )
+
+        assert litellm.completion.call_count == 1
+
+    def test_transient_error_retries(self):
+        Proxy = _load_proxy()
+        proxy = Proxy(verbose=False)
+        proxy.MAX_RETRIES = 3
+        proxy.BACKOFF_FACTOR = 0
+
+        rate_error = type("RateLimitError", (Exception,), {
+            "__module__": "litellm.exceptions"
+        })()
+        fake_resp = _make_response("recovered")
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(
+                side_effect=[rate_error, rate_error, fake_resp]
+            )
+
+            result = proxy.call(
+                model="litellm/openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                no_cache=True,
+            )
+
+        assert result == [{"message": {"content": "recovered"}}]
+        assert litellm.completion.call_count == 3


### PR DESCRIPTION
## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as an AI gateway provider, giving WriteHERE access to 100+ LLM providers (AWS Bedrock, Azure OpenAI, Google Vertex AI, Mistral, Cohere, etc.) through a single unified SDK.

## Changes

- `recursive/llm/llm.py` - Added `_call_litellm()` method in `OpenAIApiProxy` with retry logic (transient-only), caching, and usage logging. Model routing via `litellm/` prefix in `call()`.
- `requirements.txt` - Added `litellm>=1.80,<1.87`
- `tests/test_litellm.py` - 9 unit tests covering routing, params, caching, and retry behavior
- `README.md` - Added LiteLLM to prerequisites and usage examples

## Tests

**1. Unit tests (9/9 passing):**
```
tests/test_litellm.py::TestLiteLLMRouting::test_litellm_prefix_routes_correctly PASSED
tests/test_litellm.py::TestLiteLLMRouting::test_non_litellm_model_does_not_route_to_litellm PASSED
tests/test_litellm.py::TestLiteLLMCallParams::test_drop_params_true_by_default PASSED
tests/test_litellm.py::TestLiteLLMCallParams::test_temperature_forwarded PASSED
tests/test_litellm.py::TestLiteLLMCallParams::test_temperature_omitted_when_none PASSED
tests/test_litellm.py::TestLiteLLMCallParams::test_max_tokens_set_to_8192 PASSED
tests/test_litellm.py::TestLiteLLMCaching::test_cache_hit_skips_api_call PASSED
tests/test_litellm.py::TestLiteLLMRetry::test_non_transient_error_raises_immediately PASSED
tests/test_litellm.py::TestLiteLLMRetry::test_transient_error_retries PASSED

9 passed in 0.22s
```

**2. Live E2E against Anthropic via LiteLLM SDK:**
```python
from recursive.llm.llm import OpenAIApiProxy
proxy = OpenAIApiProxy(verbose=True)
result = proxy.call(
    model='litellm/anthropic/claude-sonnet-4-6',
    messages=[
        {'role': 'system', 'content': 'You are a helpful assistant.'},
        {'role': 'user', 'content': 'What is 2+2? Answer in one word.'}
    ],
    no_cache=True, temperature=0.0,
)
# Output:
# anthropic/claude-sonnet-4-6 Usage: input=26, output=4
# Content: Four
```

## Example usage

```bash
# Use any LiteLLM-supported model by prefixing with "litellm/"
python recursive/engine.py --model litellm/anthropic/claude-sonnet-4-6 ...
python recursive/engine.py --model litellm/bedrock/anthropic.claude-3-sonnet-20240229-v1:0 ...
python recursive/engine.py --model litellm/azure/gpt-4 ...
python recursive/engine.py --model litellm/vertex_ai/gemini-pro ...
```

Set the provider's standard API key env var (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`). Full provider list: https://docs.litellm.ai/docs/providers

## Risk / Compatibility

- Additive only. Existing providers (OpenAI, Anthropic, Gemini, OpenRouter) are completely untouched.
- `litellm` is a regular pip dependency, no change to the install flow.
- `drop_params=True` ensures cross-provider compatibility by silently dropping provider-unsupported kwargs.
- Only transient errors (rate limit, timeout, server errors) trigger retries; auth/validation errors fail immediately.
